### PR TITLE
Create CODE_OF_CONDUCT.md.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,95 @@
+# Contributor Covenant Code of Conduct
+
+This team will exemplify characteristics which contribute to a productive working environment for its individual members.
+
+## Our Work Habits ## Team members shall work proactively, efficiently, and precisely.
+
+  - Team members must have positive attitudes. If there are known future conflicts or times a member will be out of town, he or she should let others know.
+  - Team members shall be respectful of teammates’ time or personal cases. It is expected that members will arrive on time and not get distracted by other things while doing coursework.
+  - Team Members need to discuss with team before doing something.
+
+## Teamwork ## The team will be supportive and always work towards the advancement of team goals.
+
+  - Team members shall read lab outlines and proposed agendas before lab and be prepared for lab activities.
+  - Team members needs to be open to hearing, debate, exchange and evaluating the ideas of others to achieve the better results on the team goals.
+  - Team members shall put the team above personal biases and accept the team’s decision once it has been made.
+  
+## Decision Making ## The team shall make educated decisions to the best of our abilities using information, research, and data available.
+
+  - All team members shall have an opportunity to give input before decisions are made.
+  - Decisions shall be based on facts, not assertions.
+ 
+## Communication ## The team will communicate honestly
+
+  - Team members (especially team leader) must know the limit of the team’s members performance skills and abilities. Members shall not take on more than they can knowingly handle.
+  - All team members shall always be given the opportunity to speak up and have their voices heard.
+  - When disagreeing with each other in the team, team members must show respect and let them to point out their opinion.
+  - All team members should have feedbacks rather than disagreement for all cases.
+  
+## Team Members ## This code-of-conduct is agreed upon by all the team members.
+
+  1. Maung Maung Oo
+  2. Zabu Kyaw
+  3. Kyaw Zaw Lwin
+  4. BoBo TunZaw
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies only within project spaces. 
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at 40437519@live.napier.ac.uk. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq


### PR DESCRIPTION
Initial code of conduct already defined in the READEME.md file in the project, this code of conduct file is referenced from contributor Covenant code of conduct template along with the initial data from readme.